### PR TITLE
Fix cluster name logic

### DIFF
--- a/internal/controller/managedmetric_controller.go
+++ b/internal/controller/managedmetric_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"strings"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -309,11 +308,7 @@ func getClusterInfo(config *rest.Config) (string, error) {
 		return "localhost", nil
 	}
 
-	// Remove any prefix (like "kubernetes" or "kubernetes.default.svc")
-	parts := strings.Split(hostname, ".")
-	clusterName := parts[0]
-
-	return clusterName, nil
+	return hostname, nil
 }
 
 // OrchestratorFactory is a function type for creating orchestrators

--- a/internal/controller/metric_controller_helpers_test.go
+++ b/internal/controller/metric_controller_helpers_test.go
@@ -45,22 +45,22 @@ func TestGetClusterInfo(t *testing.T) {
 		{
 			name:         "KubernetesService",
 			host:         "https://kubernetes.default.svc:6443",
-			expectedName: "kubernetes",
+			expectedName: "kubernetes.default.svc",
 		},
 		{
 			name:         "CustomClusterName",
 			host:         "https://my-cluster-api.example.com:6443",
-			expectedName: "my-cluster-api",
+			expectedName: "my-cluster-api.example.com",
 		},
 		{
 			name:         "IPAddress",
 			host:         "https://192.168.1.1:6443",
-			expectedName: "192", // The function only extracts the first part of the IP address
+			expectedName: "192.168.1.1", // The function only extracts the first part of the IP address
 		},
 		{
 			name:         "WithPath",
 			host:         "https://kubernetes.default.svc:6443/api",
-			expectedName: "kubernetes",
+			expectedName: "kubernetes.default.svc",
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR fixes the `metric.attributes.cluster` dimensions to provide the whole hostname, as with the current parsing logic, only a subset (mainly only the `api` string) of the hostname is presented to the end user (on the respective backend). The information is not particularly useful if you want to determine which cluster the metric originates from, hence the current PR proposal

**Which issue(s) this PR fixes**: 
Fixes #

**Special notes for your reviewer**:

**Release note**:
```feature user
Fixes hostname parsing
```